### PR TITLE
Update Redoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/Redocly/apidocs-starter#readme",
   "dependencies": {
-    "@redocly/redoc": "^0.94.2"
+    "@redocly/redoc": "^0.102.0"
   }
 }


### PR DESCRIPTION
We need a newer Redoc version to get the preview command in place.